### PR TITLE
Add CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(fractal-tree-opengl LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(OpenGL REQUIRED)
+include_directories(${OPENGL_INCLUDE_DIR})
+link_directories(${OPENGL_INCLUDE_DIR})
+
+find_package(glfw3 REQUIRED)
+include_directories(${GLFW_INCLUDE_DIR})
+link_directories(${GLFW_INCLUDE_DIR})
+
+find_package(GLEW REQUIRED)
+include_directories(${GLEW_INCLUDE_DIR})
+link_directories(${GLEW_INCLUDE_DIR})
+
+list(APPEND LIB_LIST
+	${OPENGL_LIBRARIES}
+	${GLEW_LIBRARIES}
+	${GLFW_LIBRARIES})
+
+add_executable(fractal-tree-opengl code/main.cpp)
+
+target_link_libraries(fractal-tree-opengl ${LIB_LIST} glfw)
+
+install(TARGETS fractal-tree-opengl
+    RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Dzień dobry,
Przygotowałem dla Pana plik konfiguracyjny dla `CMake`. To pozwoli uruchomić Pana przykład na większości systemów operacyjnych. Używając `CMake` należy:
``` shell
md build-test-gl # utworzyć katalog budowania
cd build-test-gl # przejść do katalogu budowania
cmake ../fractal-tree-opengl # skonfigurować projekt
cmake --build . # zbudować projekt
```

Należy również zmienić ścieżkę do nagłówków (zwykle są one w osobnych folderach; `CMake` doda je do `includepath`):
``` cpp
#include <GL/glew.h>
#include <GLFW/glfw3.h>
```

Zachęcam do zapoznania się z `CMake` lub `Meson` - w przyszłości z pewnością będzie to cenne.